### PR TITLE
Update IOperatorFilterRegistry.sol

### DIFF
--- a/src/IOperatorFilterRegistry.sol
+++ b/src/IOperatorFilterRegistry.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
-
 interface IOperatorFilterRegistry {
     function isOperatorAllowed(address registrant, address operator) external returns (bool);
     function register(address registrant) external;


### PR DESCRIPTION
EnumerableSet is not needed.