### PR TITLE
Update README and OpenSea curated filter to remove Blur ExecutionDelegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,6 @@ Entries in this list are added according to the following criteria:
 </tr>
 
 <tr>
-<td>Blur.io ExecutionDelegate</td>
-<td >
-0x00000000000111AbE46ff893f3B2fdF1F759a8A8
-</td>
-<td >
-Ethereum Mainnet
-</td>
-</tr>
-
-<tr>
 <td>LooksRare TransferManagerERC721</td>
 <td>0xf42aa99F011A1fA7CDA90E5E98b277E306BcA83e</td>
 <td>Ethereum Mainnet</td>


### PR DESCRIPTION
Blur now enforces royalties on NFTs that implement filtering https://twitter.com/blur_io/status/1592203711354261504?s=20&t=RQIV8F3LriskYIO_lpz-IA.

The README and on-chain filter list at `0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6` should be updated so that creators can earn royalties on Blur.