### PR TITLE
refactor: constant name in capitalized SNAKE_CASE

### DIFF
--- a/src/OperatorFilterer.sol
+++ b/src/OperatorFilterer.sol
@@ -6,21 +6,21 @@ import {IOperatorFilterRegistry} from "./IOperatorFilterRegistry.sol";
 abstract contract OperatorFilterer {
     error OperatorNotAllowed(address operator);
 
-    IOperatorFilterRegistry constant operatorFilterRegistry =
+    IOperatorFilterRegistry constant OPERATOR_FILTER_REGISTRY =
         IOperatorFilterRegistry(0x000000000000AAeB6D7670E522A718067333cd4E);
 
     constructor(address subscriptionOrRegistrantToCopy, bool subscribe) {
         // If an inheriting token contract is deployed to a network without the registry deployed, the modifier
         // will not revert, but the contract will need to be registered with the registry once it is deployed in
         // order for the modifier to filter addresses.
-        if (address(operatorFilterRegistry).code.length > 0) {
+        if (address(OPERATOR_FILTER_REGISTRY).code.length > 0) {
             if (subscribe) {
-                operatorFilterRegistry.registerAndSubscribe(address(this), subscriptionOrRegistrantToCopy);
+                OPERATOR_FILTER_REGISTRY.registerAndSubscribe(address(this), subscriptionOrRegistrantToCopy);
             } else {
                 if (subscriptionOrRegistrantToCopy != address(0)) {
-                    operatorFilterRegistry.registerAndCopyEntries(address(this), subscriptionOrRegistrantToCopy);
+                    OPERATOR_FILTER_REGISTRY.registerAndCopyEntries(address(this), subscriptionOrRegistrantToCopy);
                 } else {
-                    operatorFilterRegistry.register(address(this));
+                    OPERATOR_FILTER_REGISTRY.register(address(this));
                 }
             }
         }
@@ -28,7 +28,7 @@ abstract contract OperatorFilterer {
 
     modifier onlyAllowedOperator(address from) virtual {
         // Check registry code length to facilitate testing in environments without a deployed registry.
-        if (address(operatorFilterRegistry).code.length > 0) {
+        if (address(OPERATOR_FILTER_REGISTRY).code.length > 0) {
             // Allow spending tokens from addresses with balance
             // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
             // from an EOA.
@@ -38,8 +38,8 @@ abstract contract OperatorFilterer {
             }
             if (
                 !(
-                    operatorFilterRegistry.isOperatorAllowed(address(this), msg.sender)
-                        && operatorFilterRegistry.isOperatorAllowed(address(this), from)
+                    OPERATOR_FILTER_REGISTRY.isOperatorAllowed(address(this), msg.sender)
+                        && OPERATOR_FILTER_REGISTRY.isOperatorAllowed(address(this), from)
                 )
             ) {
                 revert OperatorNotAllowed(msg.sender);


### PR DESCRIPTION
For consistency, this PR renames `operatorFilterRegistry` -> `OPERATOR_FILTER_REGISTRY`.

Just like the `DEFAULT_SUBSCRIPTION` in `DefaultOperatorFilterer.sol`, the constant name should be in capitalized SNAKE_CASE.