### PR TITLE
refactor: operator filterer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ This method will toggle filtering on code hashes of operators given registrant. 
 
 ## `OperatorFilterer`
 
-This smart contract is meant to be inherited by token contracts so they can use the `onlyAllowedOperator` modifier on the `transferFrom` and `safeTransferFrom` methods.
+This smart contract is meant to be inherited by token contracts so they can use the following:
+- `onlyAllowedOperator` modifier for `transferFrom` and `safeTransferFrom` methods.
+- `onlyAllowedOperatorApproval` modifier for `approve` and `setApprovalForAll` methods.
 
 On construction, it takes three parameters:
 - `address registry`: the address of the `OperatorFilterRegistry` contract

--- a/src/OperatorFilterer.sol
+++ b/src/OperatorFilterer.sol
@@ -7,6 +7,9 @@ import {IOperatorFilterRegistry} from "./IOperatorFilterRegistry.sol";
  * @title  OperatorFilterer
  * @notice Abstract contract whose constructor automatically registers and optionally subscribes to or copies another
  *         registrant's entries in the OperatorFilterRegistry.
+ * @dev    This smart contract is meant to be inherited by token contracts so they can use the following:
+ *         - `onlyAllowedOperator` modifier for `transferFrom` and `safeTransferFrom` methods.
+ *         - `onlyAllowedOperatorApproval` modifier for `approve` and `setApprovalForAll` methods.
  */
 abstract contract OperatorFilterer {
     error OperatorNotAllowed(address operator);


### PR DESCRIPTION
This PR adds comment for `OperatorFilterer` contract and updates README.md with `onlyAllowedOperatorApproval` modifier which has been added since https://github.com/ProjectOpenSea/operator-filter-registry/pull/26.