### PR TITLE
feat: public constant OPERATOR_FILTER_REGISTRY

### DIFF
--- a/src/OperatorFilterer.sol
+++ b/src/OperatorFilterer.sol
@@ -11,7 +11,7 @@ import {IOperatorFilterRegistry} from "./IOperatorFilterRegistry.sol";
 abstract contract OperatorFilterer {
     error OperatorNotAllowed(address operator);
 
-    IOperatorFilterRegistry constant OPERATOR_FILTER_REGISTRY =
+    IOperatorFilterRegistry public constant OPERATOR_FILTER_REGISTRY =
         IOperatorFilterRegistry(0x000000000000AAeB6D7670E522A718067333cd4E);
 
     constructor(address subscriptionOrRegistrantToCopy, bool subscribe) {


### PR DESCRIPTION
This PR changes the state visibility of the constant `OPERATOR_FILTER_REGISTRY` from `internal` to `public`.

With this, users can use the getter function to read the value.