### PR TITLE
Reorganize OperatorFilter modifiers to be easier to override 

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ libs = ['lib']
 optimizer_runs = 1_000_000
 solc = '0.8.17'
 remappings = [
+    'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts',
     'openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts',
 ]
 

--- a/src/OperatorFilterer.sol
+++ b/src/OperatorFilterer.sol
@@ -35,29 +35,26 @@ abstract contract OperatorFilterer {
     }
 
     modifier onlyAllowedOperator(address from) virtual {
-        // Check registry code length to facilitate testing in environments without a deployed registry.
-        if (address(OPERATOR_FILTER_REGISTRY).code.length > 0) {
-            // Allow spending tokens from addresses with balance
-            // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
-            // from an EOA.
-            if (from == msg.sender) {
-                _;
-                return;
-            }
-            if (!OPERATOR_FILTER_REGISTRY.isOperatorAllowed(address(this), msg.sender)) {
-                revert OperatorNotAllowed(msg.sender);
-            }
+        // Allow spending tokens from addresses with balance
+        // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
+        // from an EOA.
+        if (from != msg.sender) {
+            _checkFilterOperator(msg.sender);
         }
         _;
     }
 
     modifier onlyAllowedOperatorApproval(address operator) virtual {
+        _checkFilterOperator(operator);
+        _;
+    }
+    
+    function _checkFilterOperator(address operator) internal view virtual {
         // Check registry code length to facilitate testing in environments without a deployed registry.
         if (address(OPERATOR_FILTER_REGISTRY).code.length > 0) {
             if (!OPERATOR_FILTER_REGISTRY.isOperatorAllowed(address(this), operator)) {
                 revert OperatorNotAllowed(operator);
             }
         }
-        _;
     }
 }

--- a/src/RevokableOperatorFilterer.sol
+++ b/src/RevokableOperatorFilterer.sol
@@ -16,31 +16,10 @@ abstract contract RevokableOperatorFilterer is OperatorFilterer {
 
     bool private _isOperatorFilterRegistryRevoked;
 
-    modifier onlyAllowedOperator(address from) override {
-        // Check registry code length to facilitate testing in environments without a deployed registry.
-        if (!_isOperatorFilterRegistryRevoked && address(OPERATOR_FILTER_REGISTRY).code.length > 0) {
-            // Allow spending tokens from addresses with balance
-            // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
-            // from an EOA.
-            if (from == msg.sender) {
-                _;
-                return;
-            }
-            if (!OPERATOR_FILTER_REGISTRY.isOperatorAllowed(address(this), msg.sender)) {
-                revert OperatorNotAllowed(msg.sender);
-            }
+    function _checkFilterOperator(address operator) internal view virtual override {
+        if (!_isOperatorFilterRegistryRevoked) {
+            super._checkFilterOperator(operator);
         }
-        _;
-    }
-
-    modifier onlyAllowedOperatorApproval(address operator) override {
-        // Check registry code length to facilitate testing in environments without a deployed registry.
-        if (!_isOperatorFilterRegistryRevoked && address(OPERATOR_FILTER_REGISTRY).code.length > 0) {
-            if (!OPERATOR_FILTER_REGISTRY.isOperatorAllowed(address(this), operator)) {
-                revert OperatorNotAllowed(operator);
-            }
-        }
-        _;
     }
 
     /**


### PR DESCRIPTION
As explained in #47, checking the codesize of an external address is way more expensive than doing the simple from != msg.sender check and it feels more natural (and gas effective) to first check that before going into the filtering shenanigans: there is no reason to deploy contracts using the OperatorFilter on networks where it's not, so the check "from != msg.sender" should normally always be performed, so better do it before checking any external stuff.

When the check is then put first, it appears that the code used to check if an operator is allowed can be put in its own internal function, making the code more DRY but also [easier to override](https://github.com/dievardump/operator-filter-registry/blob/e7a7f4003045b60762b186c1d9ccb9cacceb7eae/src/RevokableOperatorFilterer.sol) when we want to add things like switches

It adds a small gas overhead of 150gas, but we can sure all agree that this OperatorFilterRegistry is already introducing so much gas overhead that 150 gas in order to have a cleaner and more usable code is nothing.