### PR TITLE
chore: use `files` field, instead of .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-/lib
-/.github
-/script
-/test
-/.gas-snapshot
-/foundry.toml
-/sample.env

--- a/package.json
+++ b/package.json
@@ -7,5 +7,12 @@
     "dependencies": {
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.8.0"
-    }
+    },
+    "files": [
+        "node_modules",
+        "package.json",
+        "src",
+        "LICENSE",
+        "README.md"
+    ]
 }


### PR DESCRIPTION
## Description

This PR uses `files` field in package.json instead of using .npmignore.
It's easier to manage allowlist (`files` field in package.json), compared to blocklist (.npmignore).

Also, it prevents `.prettierrc` and `.gitmodules` being published.
In operator-filter-registry `v1.3.0`, the unnecessary `.prettierrc` and `.gitmodules` are included.

For testing, you can run `npm publish --dry-run` which shows the following:
```
npm notice 📦  operator-filter-registry@1.3.0
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE                                                        
npm notice 11.3kB README.md                                                      
npm notice 487B   package.json                                                   
npm notice 497B   src/DefaultOperatorFilterer.sol                                
npm notice 1.8kB  src/example/ExampleERC721.sol                                  
npm notice 1.6kB  src/example/ExampleERC1155.sol                                 
npm notice 2.2kB  src/example/RevokableExampleERC721.sol                         
npm notice 2.0kB  src/example/RevokableExampleERC1155.sol                        
npm notice 2.0kB  src/example/upgradeable/ExampleERC721Upgradeable.sol           
npm notice 1.8kB  src/example/upgradeable/ExampleERC1155Upgradeable.sol          
npm notice 2.4kB  src/example/upgradeable/RevokableExampleERC721Upgradeable.sol  
npm notice 2.2kB  src/example/upgradeable/RevokableExampleERC1155Upgradeable.sol 
npm notice 2.1kB  src/IOperatorFilterRegistry.sol                                
npm notice 2.7kB  src/OperatorFilterer.sol                                       
npm notice 22.0kB src/OperatorFilterRegistry.sol                                 
npm notice 1.5kB  src/OperatorFilterRegistryErrorsAndEvents.sol                  
npm notice 697B   src/OwnedRegistrant.sol                                        
npm notice 781B   src/RevokableDefaultOperatorFilterer.sol                       
npm notice 3.0kB  src/RevokableOperatorFilterer.sol                              
npm notice 3.8kB  src/UpdatableOperatorFilterer.sol                              
npm notice 493B   src/upgradeable/DefaultOperatorFiltererUpgradeable.sol         
npm notice 2.7kB  src/upgradeable/OperatorFiltererUpgradeable.sol                
npm notice 556B   src/upgradeable/RevokableDefaultOperatorFiltererUpgradeable.sol
npm notice 3.0kB  src/upgradeable/RevokableOperatorFiltererUpgradeable.sol       
npm notice === Tarball Details === 
npm notice name:          operator-filter-registry                
npm notice version:       1.3.0                                   
npm notice filename:      operator-filter-registry-1.3.0.tgz      
npm notice package size:  12.9 kB                                 
npm notice unpacked size: 72.9 kB                                 
npm notice shasum:        c435321b830147490ccb01fa477eda2be10fb836
npm notice integrity:     sha512-MQMyiefDpmDzM[...]m7LVYHHYvsGjg==
npm notice total files:   24                                      
npm notice 
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
```




