### PR TITLE
fix: remove redundant conditional statements to optimise Gas consumption

### DIFF
--- a/src/OperatorFilterRegistry.sol
+++ b/src/OperatorFilterRegistry.sol
@@ -438,10 +438,7 @@ contract OperatorFilterRegistry is IOperatorFilterRegistry, OperatorFilterRegist
      */
     function isOperatorFiltered(address registrant, address operator) external view returns (bool) {
         address registration = _registrations[registrant];
-        if (registration != registrant) {
-            return _filteredOperators[registration].contains(operator);
-        }
-        return _filteredOperators[registrant].contains(operator);
+        return _filteredOperators[registration].contains(operator);
     }
 
     /**
@@ -449,10 +446,7 @@ contract OperatorFilterRegistry is IOperatorFilterRegistry, OperatorFilterRegist
      */
     function isCodeHashFiltered(address registrant, bytes32 codeHash) external view returns (bool) {
         address registration = _registrations[registrant];
-        if (registration != registrant) {
-            return _filteredCodeHashes[registration].contains(codeHash);
-        }
-        return _filteredCodeHashes[registrant].contains(codeHash);
+        return _filteredCodeHashes[registration].contains(codeHash);
     }
 
     /**
@@ -461,10 +455,7 @@ contract OperatorFilterRegistry is IOperatorFilterRegistry, OperatorFilterRegist
     function isCodeHashOfFiltered(address registrant, address operatorWithCode) external view returns (bool) {
         bytes32 codeHash = operatorWithCode.codehash;
         address registration = _registrations[registrant];
-        if (registration != registrant) {
-            return _filteredCodeHashes[registration].contains(codeHash);
-        }
-        return _filteredCodeHashes[registrant].contains(codeHash);
+        return _filteredCodeHashes[registration].contains(codeHash);
     }
 
     /**
@@ -479,10 +470,7 @@ contract OperatorFilterRegistry is IOperatorFilterRegistry, OperatorFilterRegist
      */
     function filteredOperators(address registrant) external view returns (address[] memory) {
         address registration = _registrations[registrant];
-        if (registration != registrant) {
-            return _filteredOperators[registration].values();
-        }
-        return _filteredOperators[registrant].values();
+        return _filteredOperators[registration].values();
     }
 
     /**
@@ -491,10 +479,7 @@ contract OperatorFilterRegistry is IOperatorFilterRegistry, OperatorFilterRegist
      */
     function filteredCodeHashes(address registrant) external view returns (bytes32[] memory) {
         address registration = _registrations[registrant];
-        if (registration != registrant) {
-            return _filteredCodeHashes[registration].values();
-        }
-        return _filteredCodeHashes[registrant].values();
+        return _filteredCodeHashes[registration].values();
     }
 
     /**
@@ -504,10 +489,7 @@ contract OperatorFilterRegistry is IOperatorFilterRegistry, OperatorFilterRegist
      */
     function filteredOperatorAt(address registrant, uint256 index) external view returns (address) {
         address registration = _registrations[registrant];
-        if (registration != registrant) {
-            return _filteredOperators[registration].at(index);
-        }
-        return _filteredOperators[registrant].at(index);
+        return _filteredOperators[registration].at(index);
     }
 
     /**
@@ -517,10 +499,7 @@ contract OperatorFilterRegistry is IOperatorFilterRegistry, OperatorFilterRegist
      */
     function filteredCodeHashAt(address registrant, uint256 index) external view returns (bytes32) {
         address registration = _registrations[registrant];
-        if (registration != registrant) {
-            return _filteredCodeHashes[registration].at(index);
-        }
-        return _filteredCodeHashes[registrant].at(index);
+        return _filteredCodeHashes[registration].at(index);
     }
 
     /// @dev Convenience method to compute the code hash of an arbitrary contract


### PR DESCRIPTION
There is no reason to keep these redundant conditional statements.

Here is the detailed explanation:
  
This code:
```
if (registration != registrant) {
        return _filteredOperators[registration].contains(operator);
}
return _filteredOperators[registrant].contains(operator);
```
is equal to this:
```
if (registration != registrant) {
        return _filteredOperators[registration].contains(operator);
} else if (registration == registrant) {
        return _filteredOperators[registrant].contains(operator);
}
```
which means that if the statement `registration == registrant` is `true` then
`return _filteredOperators[registrant].contains(operator);` equals to `return _filteredOperators[registration].contains(operator);`
this means that we may get rid of the conditional statements.