### PR TITLE
Use OZ hooks for transfer filter to clean up example code

### DIFF
--- a/src/example/ExampleERC1155.sol
+++ b/src/example/ExampleERC1155.sol
@@ -24,29 +24,18 @@ abstract contract ExampleERC1155 is ERC1155(""), ERC2981, DefaultOperatorFiltere
     }
 
     /**
-     * @dev See {IERC1155-safeTransferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
+     * @dev See {ERC1155-_beforeTokenTransfer}.
+     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry before any token transfer.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId, uint256 amount, bytes memory data)
-        public
-        override
-        onlyAllowedOperator(from)
-    {
-        super.safeTransferFrom(from, to, tokenId, amount, data);
-    }
-
-    /**
-     * @dev See {IERC1155-safeBatchTransferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
-     */
-    function safeBatchTransferFrom(
+    function _beforeTokenTransfer(
+        address operator,
         address from,
         address to,
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory data
-    ) public virtual override onlyAllowedOperator(from) {
-        super.safeBatchTransferFrom(from, to, ids, amounts, data);
+    ) internal virtual override onlyAllowedOperator(from) {
+        super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
     }
 
     /**

--- a/src/example/ExampleERC721.sol
+++ b/src/example/ExampleERC721.sol
@@ -32,31 +32,16 @@ abstract contract ExampleERC721 is ERC721("Example", "EXAMPLE"), ERC2981, Defaul
     }
 
     /**
-     * @dev See {IERC721-transferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
+     * @dev See {IERC721-_beforeTokenTransfer}.
+     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry before any token transfer.
      */
-    function transferFrom(address from, address to, uint256 tokenId) public override onlyAllowedOperator(from) {
-        super.transferFrom(from, to, tokenId);
-    }
-
-    /**
-     * @dev See {IERC721-safeTransferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
-     */
-    function safeTransferFrom(address from, address to, uint256 tokenId) public override onlyAllowedOperator(from) {
-        super.safeTransferFrom(from, to, tokenId);
-    }
-
-    /**
-     * @dev See {IERC721-safeTransferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
-     */
-    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data)
-        public
-        override
-        onlyAllowedOperator(from)
-    {
-        super.safeTransferFrom(from, to, tokenId, data);
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 firstTokenId,
+        uint256 batchSize
+    ) internal virtual override onlyAllowedOperatorApproval(from) {
+        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
     }
 
     /**

--- a/src/example/upgradeable/ExampleERC1155Upgradeable.sol
+++ b/src/example/upgradeable/ExampleERC1155Upgradeable.sol
@@ -38,29 +38,18 @@ abstract contract ExampleERC1155Upgradeable is
     }
 
     /**
-     * @dev See {IERC1155-safeTransferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
+     * @dev See {IERC1155Upgradeable-_beforeTokenTransfer}.
+     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry before any token transfer.
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId, uint256 amount, bytes memory data)
-        public
-        override
-        onlyAllowedOperator(from)
-    {
-        super.safeTransferFrom(from, to, tokenId, amount, data);
-    }
-
-    /**
-     * @dev See {IERC1155-safeBatchTransferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
-     */
-    function safeBatchTransferFrom(
+    function _beforeTokenTransfer(
+        address operator,
         address from,
         address to,
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory data
-    ) public virtual override onlyAllowedOperator(from) {
-        super.safeBatchTransferFrom(from, to, ids, amounts, data);
+    ) internal virtual override onlyAllowedOperator(from) {
+        super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
     }
 
     /**
@@ -70,7 +59,7 @@ abstract contract ExampleERC1155Upgradeable is
         public
         view
         virtual
-        override (ERC1155Upgradeable, ERC2981Upgradeable)
+        override(ERC1155Upgradeable, ERC2981Upgradeable)
         returns (bool)
     {
         return super.supportsInterface(interfaceId);

--- a/src/example/upgradeable/ExampleERC721Upgradeable.sol
+++ b/src/example/upgradeable/ExampleERC721Upgradeable.sol
@@ -46,31 +46,16 @@ abstract contract ExampleERC721Upgradeable is
     }
 
     /**
-     * @dev See {IERC721-transferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
+     * @dev See {IERC721Upgradeable-_beforeTokenTransfer}.
+     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry before any token transfer.
      */
-    function transferFrom(address from, address to, uint256 tokenId) public override onlyAllowedOperator(from) {
-        super.transferFrom(from, to, tokenId);
-    }
-
-    /**
-     * @dev See {IERC721-safeTransferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
-     */
-    function safeTransferFrom(address from, address to, uint256 tokenId) public override onlyAllowedOperator(from) {
-        super.safeTransferFrom(from, to, tokenId);
-    }
-
-    /**
-     * @dev See {IERC721-safeTransferFrom}.
-     *      In this example the added modifier ensures that the operator is allowed by the OperatorFilterRegistry.
-     */
-    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data)
-        public
-        override
-        onlyAllowedOperator(from)
-    {
-        super.safeTransferFrom(from, to, tokenId, data);
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 firstTokenId,
+        uint256 batchSize
+    ) internal virtual override onlyAllowedOperatorApproval(from) {
+        super._beforeTokenTransfer(from, to, firstTokenId, batchSize);
     }
 
     /**
@@ -80,7 +65,7 @@ abstract contract ExampleERC721Upgradeable is
         public
         view
         virtual
-        override (ERC721Upgradeable, ERC2981Upgradeable)
+        override(ERC721Upgradeable, ERC2981Upgradeable)
         returns (bool)
     {
         return super.supportsInterface(interfaceId);


### PR DESCRIPTION
This updates the example code to use the OZ before transfer hook to clean up the code.