### PR TITLE
Gas optimization: don't check registry on mint

### DIFF
--- a/src/OperatorFilterer.sol
+++ b/src/OperatorFilterer.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {IOperatorFilterRegistry} from "./IOperatorFilterRegistry.sol";
 import {CANONICAL_OPERATOR_FILTER_REGISTRY_ADDRESS} from "./lib/Constants.sol";
+
 /**
  * @title  OperatorFilterer
  * @notice Abstract contract whose constructor automatically registers and optionally subscribes to or copies another
@@ -47,7 +48,9 @@ abstract contract OperatorFilterer {
         // Allow spending tokens from addresses with balance
         // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
         // from an EOA.
-        if (from != msg.sender) {
+        // Note: this does not check filterers on mint as a gas optimization since
+        // unapproved marketplaces cannot mint unless intentionally setup by the token author.
+        if (from != msg.sender && from != address(0)) {
             _checkFilterOperator(msg.sender);
         }
         _;

--- a/src/upgradeable/OperatorFiltererUpgradeable.sol
+++ b/src/upgradeable/OperatorFiltererUpgradeable.sol
@@ -49,7 +49,9 @@ abstract contract OperatorFiltererUpgradeable is Initializable {
         // Allow spending tokens from addresses with balance
         // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
         // from an EOA.
-        if (from != msg.sender) {
+        // Note: this does not check filterers on mint as a gas optimization since
+        // unapproved marketplaces cannot mint unless intentionally setup by the token author.
+        if (from != msg.sender && from != address(0)) {
             _checkFilterOperator(msg.sender);
         }
         _;

--- a/test/DefaultOperatorFilterer.t.sol
+++ b/test/DefaultOperatorFilterer.t.sol
@@ -39,11 +39,11 @@ contract DefaultOperatorFiltererTest is BaseRegistryTest {
         assertTrue(filterer.filterTest(notFiltered));
         vm.startPrank(filteredAddress);
         vm.expectRevert(abi.encodeWithSelector(AddressFiltered.selector, filteredAddress));
-        filterer.filterTest(address(0));
+        filterer.filterTest(address(0x1));
         vm.stopPrank();
         vm.startPrank(filteredCodeHashAddress);
         vm.expectRevert(abi.encodeWithSelector(CodeHashFiltered.selector, filteredCodeHashAddress, filteredCodeHash));
-        filterer.filterTest(address(0));
+        filterer.filterTest(address(0x1));
     }
 
     function testRevert_OperatorNotAllowed() public {

--- a/test/OperatorFilterer.t.sol
+++ b/test/OperatorFilterer.t.sol
@@ -36,11 +36,11 @@ contract OperatorFiltererTest1 is BaseRegistryTest {
         assertTrue(filterer.testFilter(notFiltered));
         vm.startPrank(filteredAddress);
         vm.expectRevert(abi.encodeWithSelector(AddressFiltered.selector, filteredAddress));
-        filterer.testFilter(address(0));
+        filterer.testFilter(address(0x1));
         vm.stopPrank();
         vm.startPrank(filteredCodeHashAddress);
         vm.expectRevert(abi.encodeWithSelector(CodeHashFiltered.selector, filteredCodeHashAddress, filteredCodeHash));
-        filterer.testFilter(address(0));
+        filterer.testFilter(address(0x1));
     }
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);


### PR DESCRIPTION
This saves an external contract call and read on mint transactions which are quite common and never filtered by the operator filterer pattern.

This saves gas by preventing an external contract read / lookup during a mint.