### PR TITLE
Change Constants pragma to ^0.8.13

### DIFF
--- a/src/lib/Constants.sol
+++ b/src/lib/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.13;
 
 address constant CANONICAL_OPERATOR_FILTER_REGISTRY_ADDRESS = 0x000000000000AAeB6D7670E522A718067333cd4E;
 address constant CANONICAL_CORI_SUBSCRIPTION = 0x3cc6CddA760b79bAfa08dF41ECFA224f810dCeB6;


### PR DESCRIPTION
All source files require Solidity `^0.8.13` besides `Constants.sol`, which requires `^0.8.17`: https://github.com/search?q=repo%3AProjectOpenSea%2Foperator-filter-registry+pragma+solidity+path%3Asrc%2F&type=code&p=1

As a result, when you attempt to use the `DefaultOperatorFilterer` with a Solidity version between `0.8.13` and `0.8.16`, you receive the following error: `ParserError: Source file requires different compiler version`. 

`Constants.sol` does not appear to leverage any language features that require Solidity version `0.8.17`, so updating the pragma allows the Operator Filter to compile with a wider range of Solidity versions.